### PR TITLE
TASK: Make Neos 9 compatible

### DIFF
--- a/Resources/Private/Fusion/Prototypes/AssetLink.fusion
+++ b/Resources/Private/Fusion/Prototypes/AssetLink.fusion
@@ -4,7 +4,7 @@ prototype(CodeQ.Link:AssetLink) < prototype(CodeQ.Link:Link) {
     backendLink = true
 
     # map to transfer object
-    enforceNoLinkTag = ${node.context.inBackend && !this.backendLink ? true : false}
+    enforceNoLinkTag = ${renderingMode.isEdit && !this.backendLink ? true : false}
     link = ${this.asset}
     link.@process.toUri = Neos.Fusion:ResourceUri {
         resource = ${value.resource}

--- a/Resources/Private/Fusion/Prototypes/AssetLink.fusion
+++ b/Resources/Private/Fusion/Prototypes/AssetLink.fusion
@@ -4,7 +4,7 @@ prototype(CodeQ.Link:AssetLink) < prototype(CodeQ.Link:Link) {
     backendLink = true
 
     # map to transfer object
-    enforceNoLinkTag = ${renderingMode.isEdit && !this.backendLink ? true : false}
+    enforceNoLinkTag = ${!this.backendLink && (renderingMode ? renderingMode.isEdit : node.context.inBackend) ? true : false}
     link = ${this.asset}
     link.@process.toUri = Neos.Fusion:ResourceUri {
         resource = ${value.resource}

--- a/Resources/Private/Fusion/Prototypes/NodeLink.fusion
+++ b/Resources/Private/Fusion/Prototypes/NodeLink.fusion
@@ -9,7 +9,7 @@ prototype(CodeQ.Link:NodeLink) < prototype(CodeQ.Link:Link) {
         absolute = ${this.absolute}
         node = ${this.node}
     }
-    enforceNoLinkTag = ${node.context.inBackend && !this.backendLink ? true : false}
+    enforceNoLinkTag = ${renderingMode.isEdit && !this.backendLink ? true : false}
     link = Neos.Neos:NodeUri {
         @if.has = ${node}
         node = ${node}

--- a/Resources/Private/Fusion/Prototypes/NodeLink.fusion
+++ b/Resources/Private/Fusion/Prototypes/NodeLink.fusion
@@ -9,7 +9,7 @@ prototype(CodeQ.Link:NodeLink) < prototype(CodeQ.Link:Link) {
         absolute = ${this.absolute}
         node = ${this.node}
     }
-    enforceNoLinkTag = ${renderingMode.isEdit && !this.backendLink ? true : false}
+    enforceNoLinkTag = ${!this.backendLink && (renderingMode ? renderingMode.isEdit : node.context.inBackend) ? true : false}
     link = Neos.Neos:NodeUri {
         @if.has = ${node}
         node = ${node}

--- a/Resources/Private/Fusion/Prototypes/StringLink.fusion
+++ b/Resources/Private/Fusion/Prototypes/StringLink.fusion
@@ -17,7 +17,7 @@ prototype(CodeQ.Link:StringLink) < prototype(Neos.Fusion:Component) {
     # map to transfer object
     linkType = ${Neos.Link.getScheme(this.link)}
     renderer = CodeQ.Link:Link {
-        enforceNoLinkTag = ${node.context.inBackend && !props.backendLink ? true : false}
+        enforceNoLinkTag = ${renderingMode.isEdit && !props.backendLink ? true : false}
         label = Neos.Fusion:Case {
             isOverride {
                 condition = ${props.label != 'will-be-calculated'}

--- a/Resources/Private/Fusion/Prototypes/StringLink.fusion
+++ b/Resources/Private/Fusion/Prototypes/StringLink.fusion
@@ -17,7 +17,7 @@ prototype(CodeQ.Link:StringLink) < prototype(Neos.Fusion:Component) {
     # map to transfer object
     linkType = ${Neos.Link.getScheme(this.link)}
     renderer = CodeQ.Link:Link {
-        enforceNoLinkTag = ${renderingMode.isEdit && !props.backendLink ? true : false}
+        enforceNoLinkTag = ${!props.backendLink && (renderingMode ? renderingMode.isEdit : node.context.inBackend) ? true : false}
         label = Neos.Fusion:Case {
             isOverride {
                 condition = ${props.label != 'will-be-calculated'}

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "type": "neos-package",
     "license": "GPL-3.0-or-later",
     "require": {
-        "neos/neos": "^9.0 || dev-master",
-        "neos/fusion-afx": "^9.0 || dev-master"
+        "neos/neos": "^4.3 || 5 - 9 || dev-master",
+        "neos/fusion-afx": "^1.2 || 7 - 9 || dev-master"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest"

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "type": "neos-package",
     "license": "GPL-3.0-or-later",
     "require": {
-        "neos/neos": "^4.3 || 5 - 8 || dev-master",
-        "neos/fusion-afx": "^1.2 || 7 - 8 || dev-master"
+        "neos/neos": "^9.0 || dev-master",
+        "neos/fusion-afx": "^9.0 || dev-master"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest"


### PR DESCRIPTION
For Neos 9, we had to change how we evaluate whether we are in the backend or not. We did it in a way so that the package is backwards compatible.